### PR TITLE
Remove logging to disk with new centralized log collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 [![NPM Version](https://img.shields.io/npm/v/@bufferapp/logger.svg)](https://www.npmjs.com/package/@bufferapp/logger)
 [![Build Status](https://travis-ci.org/bufferapp/node-logger.svg?branch=master)](https://travis-ci.org/bufferapp/node-logger)
 
-Provides logging standard middleware and functions. This will always log to stdout and will
-additionally log to `/var/log/application.log` in production. This path can be overwritten using
-the `path` parameter.
+Provides standard middleware and functions for logging to stdout. In our production cluster these
+logs will be indexed in our application-logs Elasticsearch cluster as well as get backed up in s3.
 
 ## Install
 

--- a/logger.js
+++ b/logger.js
@@ -1,29 +1,13 @@
 const bunyan = require('bunyan');
 
-module.exports = function createLogger(options) {
-  const {
-    name,
-    path = '/var/log/application.log',
-  } = options;
-
+module.exports = function createLogger({ name }) {
   if (!name) {
     throw new Error('Please provide a name');
   }
 
-  const streams = [{ stream: process.stdout }];
-
-  if (process.env.NODE_ENV === 'production') {
-    streams.push({
-      type: 'rotating-file',
-      path,
-      period: '5h',
-      count: 0,
-    });
-  }
-
   const logger = bunyan.createLogger({
     name,
-    streams,
+    streams: [{ stream: process.stdout }],
     serializers: bunyan.stdSerializers,
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/logger",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Logging for Buffer.com's node applications",
   "main": "logger.js",
   "scripts": {


### PR DESCRIPTION
### Purpose

Removes logging to disk relying only on stdout logging.
### Notes

This was done in tandem with the centralized log collector developed using td-agent by the systems team. The new centralized log collector tails the Docker logs on disk. This begins the phase out of the logging sidecar container which removes the need to log to disk.
