### PR TITLE
Added fluentd forward capability

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+test/helpers/testHelper.js

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log*
 node_modules
 .npm
 /coverage
+.DS_Store

--- a/logger.js
+++ b/logger.js
@@ -1,13 +1,29 @@
 const bunyan = require('bunyan');
+const fluentL = require('fluent-logger');
 
-module.exports = function createLogger({ name }) {
+module.exports = function createLogger({ name, output, host, port }) {
   if (!name) {
     throw new Error('Please provide a name');
   }
 
+  let stream = process.stdout;
+
+  if (output === 'td-agent-forward') {
+    var sender = fluentL.createFluentSender('', {
+      host,
+      port,
+      timeout: 3.0,
+      levelTag: false,
+      reconnectInterval: 600000 // 10 minutes
+    });
+    stream = sender.toStream('application.logs');
+  } else {
+    stream = process.stdout;
+  }
+
   const logger = bunyan.createLogger({
     name,
-    streams: [{ stream: process.stdout }],
+    streams: [{ stream: stream }],
     serializers: bunyan.stdSerializers,
   });
 

--- a/logger.js
+++ b/logger.js
@@ -9,12 +9,12 @@ module.exports = function createLogger({ name, output, host, port }) {
   let stream = process.stdout;
 
   if (output === 'td-agent-forward') {
-    var sender = fluentL.createFluentSender('', {
+    const sender = fluentL.createFluentSender('', {
       host,
       port,
       timeout: 3.0,
       levelTag: false,
-      reconnectInterval: 600000 // 10 minutes
+      reconnectInterval: 600000,
     });
     stream = sender.toStream('application.logs');
   } else {
@@ -23,7 +23,7 @@ module.exports = function createLogger({ name, output, host, port }) {
 
   const logger = bunyan.createLogger({
     name,
-    streams: [{ stream: stream }],
+    streams: [{ stream }],
     serializers: bunyan.stdSerializers,
   });
 

--- a/logger.js
+++ b/logger.js
@@ -17,8 +17,6 @@ module.exports = function createLogger({ name, output, host, port }) {
       reconnectInterval: 600000,
     });
     stream = sender.toStream('application.logs');
-  } else {
-    stream = process.stdout;
   }
 
   const logger = bunyan.createLogger({

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "eslint-plugin-react": "^5.1.1",
     "istanbul": "^0.4.3",
     "mocha": "^2.5.3",
-    "msgpack-lite": "*"
+    "msgpack-lite": "^0.1.26"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/logger",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Logging for Buffer.com's node applications",
   "main": "logger.js",
   "scripts": {
@@ -21,7 +21,8 @@
   "license": "MIT",
   "dependencies": {
     "bunyan": "1.8.1",
-    "on-finished": "2.3.0"
+    "on-finished": "2.3.0",
+    "fluent-logger": "2.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -31,6 +32,7 @@
     "eslint-plugin-jsx-a11y": "^1.2.3",
     "eslint-plugin-react": "^5.1.1",
     "istanbul": "^0.4.3",
-    "mocha": "^2.5.3"
+    "mocha": "^2.5.3",
+    "msgpack-lite": "*"
   }
 }

--- a/test/helpers/testHelper.js
+++ b/test/helpers/testHelper.js
@@ -1,0 +1,91 @@
+'use strict';
+var net = require('net');
+var fs = require('fs');
+var msgpack = require('msgpack-lite');
+
+function MockFluentdServer(options){
+  var self = this;
+  this._port = null;
+  this._options = options;
+  this._received = [];
+  this._clients  = {};
+  this._server = net.createServer(function(socket){
+    var clientKey = socket.remoteAddress + ":" + socket.remotePort;
+    self._clients[clientKey] = socket;
+    socket.on('end', function(){
+      delete(self._clients[clientKey]);
+    });
+    var stream = msgpack.createDecodeStream();
+    socket.pipe(stream).on('data', function(m){
+      self._received.push({
+        tag: m[0],
+        time: m[1],
+        data: m[2],
+        options: m[3]
+      });
+      var options = m[3];
+      if (self._options.requireAckResponse && options && options.chunk) {
+        var response = {
+          ack: options.chunk
+        };
+        socket.write(msgpack.encode(response));
+      }
+    });
+  });
+}
+
+MockFluentdServer.prototype.__defineGetter__('port', function(){
+  return this._port;
+});
+
+MockFluentdServer.prototype.__defineGetter__('messages', function(){
+  return this._received;
+});
+
+
+MockFluentdServer.prototype.listen = function(callback){
+  var self = this;
+  this._server.listen(function(){
+    self._port = self._server.address().port;
+    callback();
+  });
+};
+
+MockFluentdServer.prototype.close = function(callback){
+  var self = this;
+  if( process.version.match(/^v0\.6\./) ){ // 0.6.x does not support callback for server.close();
+    this._server.close();
+    (function waitForClose(){
+      if( Object.keys(self._clients).length > 0 ){
+        setTimeout(waitForClose, 100);
+      }else{
+        callback();
+      }
+    })();
+  }else{
+    this._server.close(function(){
+      callback();
+    });
+  }
+  for(var i in self._clients){
+    self._clients[i].end();
+    // self._clients[i].destroy();
+  }
+};
+
+module.exports = {
+  runServer: function(options, callback){
+    var server = new MockFluentdServer(options);
+    server.listen(function(){
+      callback(server, function(_callback){
+         // wait 100 ms to receive all messages and then close
+         setTimeout(function(){
+           var messages = server.messages;
+           server.close(function(){
+             _callback(messages);
+           });
+         }, 100);
+       });
+    });
+  }
+};

--- a/test/testLogger.js
+++ b/test/testLogger.js
@@ -1,7 +1,9 @@
 /* eslint-env mocha */
 /* eslint padded-blocks: 0 max-len: 0 */
 const { assert } = require('chai');
+const expect = require('chai').expect;
 const StdoutCapture = require('./helpers/stdout');
+const runServer = require('./helpers/testHelper').runServer;
 const createLogger = require('../logger');
 
 const stdout = new StdoutCapture();
@@ -18,12 +20,34 @@ describe('logger', () => {
     assert.isFunction(logger.info);
   });
 
+  it('should return instance of logger for td-agent forward', () => {
+    runServer({}, function(server, finish) {
+      const logger = createLogger({ name: 'Test', output: 'td-agent-forward', port: server.port });
+      assert.isObject(logger);
+      assert.isFunction(logger.info);
+    });
+  });
+
   it('should log to stdout', () => {
     const logger = createLogger({ name: 'Test-stdout' });
     stdout.capture();
     logger.info({ metadata: { type: 'test' } }, 'Test message');
     const output = stdout.stop();
     assert.lengthOf(output, 1, 'it should output a single line');
+  });
+
+  it('should log to td-agent forward', function(done){
+    runServer({}, function(server, finish) {
+      const logger = createLogger({ name: 'Test-forward', output: 'td-agent-forward', port: server.port });
+      logger.info({ metadata: { type: 'test' } }, 'Test message');
+      setTimeout(function(){
+        finish(function(data) {
+          expect(data[0].tag).to.be.equal('application.logs');
+          expect(data[0].data).exist;
+          done();
+        });
+      }, 1000);
+    });
   });
 
   it('should log in a json encoded output', () => {
@@ -39,6 +63,23 @@ describe('logger', () => {
     }
   });
 
+  it('should log in a json encoded outout to td-agent forward', function(done){
+    runServer({}, function(server, finish) {
+      const logger = createLogger({ name: 'Test-forward', output: 'td-agent-forward', port: server.port });
+      logger.info({ metadata: { type: 'test' } }, 'Test message');
+      setTimeout(function(){
+        finish(function(data) {
+          try {
+            JSON.parse(data[0].data.message);
+          } catch (err) {
+            assert.fail(null, null, 'Could not parse output as valid JSON');
+          }
+          done();
+        });
+      }, 1000);
+    });
+  });
+
   it('should log correctly structured json', () => {
     const name = 'Test-json';
     const type = 'test';
@@ -51,6 +92,25 @@ describe('logger', () => {
     assert.equal(outputData.name, name);
     assert.equal(outputData.metadata.type, type);
     assert.equal(outputData.msg, msg);
+  });
+
+  it('should log correctly structured json to td-agent forward', function(done){
+    const name = 'Test-json';
+    const type = 'test';
+    const msg = 'Test message';
+    runServer({}, function(server, finish) {
+      const logger = createLogger({ name: name, output: 'td-agent-forward', port: server.port });
+      logger.info({ metadata: { type } }, msg);
+      setTimeout(function() {
+        finish(function(data) {
+          const outputData = JSON.parse(data[0].data.message);
+          assert.equal(outputData.name, name);
+          assert.equal(outputData.metadata.type, type);
+          assert.equal(outputData.msg, msg);
+          done();
+        });
+      }, 1000);
+    });
   });
 
   it('should log a timestamp field', () => {
@@ -70,4 +130,25 @@ describe('logger', () => {
     assert.isAtMost(timestamp, after, 'should be in range');
   });
 
+  it('should log a timestamp field to td-agent forward', function(done) {
+    const name = 'Test-timestamp';
+    runServer({}, function(server, finish) {
+      const logger = createLogger({ name: name, output: 'td-agent-forward', port: server.port });
+      const before = new Date();
+      logger.info({ metadata: { type: 'test' } }, 'Test message');
+      const after = new Date();
+      setTimeout(function() {
+        finish(function(data) {
+          const outputData = JSON.parse(data[0].data.message);
+          assert.property(outputData, 'timestamp');
+          assert.isString(outputData.timestamp, 'timestamp should be json string');
+          const timestamp = new Date(outputData.timestamp);
+          assert.instanceOf(timestamp, Date, 'timestamp can be parsed');
+          assert.isAtLeast(timestamp, before, 'should be in range');
+          assert.isAtMost(timestamp, after, 'should be in range');
+          done();
+        });
+      }, 1000);
+    });
+  });
 });

--- a/test/testLogger.js
+++ b/test/testLogger.js
@@ -21,10 +21,15 @@ describe('logger', () => {
   });
 
   it('should return instance of logger for td-agent forward', () => {
-    runServer({}, function(server, finish) {
+    runServer({}, (server, finish) => {
       const logger = createLogger({ name: 'Test', output: 'td-agent-forward', port: server.port });
       assert.isObject(logger);
       assert.isFunction(logger.info);
+      logger.info({ metadata: { type: 'test' } }, 'Test message');
+      setTimeout(() => {
+        finish(() => {
+        });
+      }, 1000);
     });
   });
 
@@ -36,14 +41,13 @@ describe('logger', () => {
     assert.lengthOf(output, 1, 'it should output a single line');
   });
 
-  it('should log to td-agent forward', function(done){
-    runServer({}, function(server, finish) {
+  it('should log to td-agent forward', (done) => {
+    runServer({}, (server, finish) => {
       const logger = createLogger({ name: 'Test-forward', output: 'td-agent-forward', port: server.port });
       logger.info({ metadata: { type: 'test' } }, 'Test message');
-      setTimeout(function(){
-        finish(function(data) {
+      setTimeout(() => {
+        finish((data) => {
           expect(data[0].tag).to.be.equal('application.logs');
-          expect(data[0].data).exist;
           done();
         });
       }, 1000);
@@ -63,12 +67,12 @@ describe('logger', () => {
     }
   });
 
-  it('should log in a json encoded outout to td-agent forward', function(done){
-    runServer({}, function(server, finish) {
+  it('should log in a json encoded outout to td-agent forward', (done) => {
+    runServer({}, (server, finish) => {
       const logger = createLogger({ name: 'Test-forward', output: 'td-agent-forward', port: server.port });
       logger.info({ metadata: { type: 'test' } }, 'Test message');
-      setTimeout(function(){
-        finish(function(data) {
+      setTimeout(() => {
+        finish((data) => {
           try {
             JSON.parse(data[0].data.message);
           } catch (err) {
@@ -94,15 +98,15 @@ describe('logger', () => {
     assert.equal(outputData.msg, msg);
   });
 
-  it('should log correctly structured json to td-agent forward', function(done){
+  it('should log correctly structured json to td-agent forward', (done) => {
     const name = 'Test-json';
     const type = 'test';
     const msg = 'Test message';
-    runServer({}, function(server, finish) {
-      const logger = createLogger({ name: name, output: 'td-agent-forward', port: server.port });
+    runServer({}, (server, finish) => {
+      const logger = createLogger({ name, output: 'td-agent-forward', port: server.port });
       logger.info({ metadata: { type } }, msg);
-      setTimeout(function() {
-        finish(function(data) {
+      setTimeout(() => {
+        finish((data) => {
           const outputData = JSON.parse(data[0].data.message);
           assert.equal(outputData.name, name);
           assert.equal(outputData.metadata.type, type);
@@ -130,15 +134,15 @@ describe('logger', () => {
     assert.isAtMost(timestamp, after, 'should be in range');
   });
 
-  it('should log a timestamp field to td-agent forward', function(done) {
+  it('should log a timestamp field to td-agent forward', (done) => {
     const name = 'Test-timestamp';
-    runServer({}, function(server, finish) {
-      const logger = createLogger({ name: name, output: 'td-agent-forward', port: server.port });
+    runServer({}, (server, finish) => {
+      const logger = createLogger({ name, output: 'td-agent-forward', port: server.port });
       const before = new Date();
       logger.info({ metadata: { type: 'test' } }, 'Test message');
       const after = new Date();
-      setTimeout(function() {
-        finish(function(data) {
+      setTimeout(() => {
+        finish((data) => {
           const outputData = JSON.parse(data[0].data.message);
           assert.property(outputData, 'timestamp');
           assert.isString(outputData.timestamp, 'timestamp should be json string');


### PR DESCRIPTION
The PR should allow `node-logger` to have a choice of outputting to `stdout` or `fluentd` forward, both using bunyan logger.

Test cases are added using a Mock fluentd daemon server :)

Would love to borrow @djfarrelly or @hharnisc's eyes on this if that's cool :D
