### PR TITLE
Filter headers and request params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9
+
+* Log only standard `request.headers`
+* Log only specified `request.params` via `params` middleware option
+
 ## 0.8
 
 * Add `getMetadata` option to append metadata with middleware

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ app.use(logMiddleware({
       userId: req.session.userId,
       profileId: req.query.profileId,
     };
-  };
+  },
 }));
 ```
 
@@ -80,7 +80,7 @@ app.use(logMiddleware({
       processingTime: responseTime - req.trackingData.externalRequestTime,
       imagesScanned: req.trackingData.imagesScanned,
     };
-  };
+  },
 }));
 // In your request handler
 app.get('/get-images', (req, res) => {
@@ -90,4 +90,14 @@ app.get('/get-images', (req, res) => {
     res.json(images);
   });
 });
+```
+
+#### Params
+
+Add logging of specific query string params using the `getMetadata` option.
+
+```js
+app.use(logMiddleware({
+  params: ['profile_id', 'utm_campaign'],
+}));
 ```

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,7 +36,30 @@ const removeTokensFromUrl = function(url) {
 };
 module.exports.removeTokensFromUrl = removeTokensFromUrl;
 
+/**
+ * pick
+ * Given an object and array of keys, return an object with only the specified fields
+ *
+ * @param {Object} obj
+ * @param {Array} keys
+ * @return {Object}
+ */
+const pick = function(obj, keys = []) {
+  return keys.reduce((picked, key) => {
+    if (key in obj) {
+      picked[key] = obj[key];
+    }
+    return picked;
+  }, {});
+};
+module.exports.pick = pick;
 
+
+const headersToLog = [
+  'user-agent',
+  'referer',
+  'cache-control',
+];
 /**
  * getRequestDataToLog
  * Given a http request object, return the proper structure to log
@@ -44,23 +67,22 @@ module.exports.removeTokensFromUrl = removeTokensFromUrl;
  * @param {http.ClientRequest} req
  * @return {Object}
  */
-const getRequestDataToLog = function(req) {
+const getRequestDataToLog = function(req, params = []) {
   const cleanUrl = removeTokensFromUrl(req.url);
   const query = req.query || parse(req.url, true).query;
 
   const request = {
     url: cleanUrl,
     method: req.method,
-    params: removeTokensFromQuery(query),
+    params: removeTokensFromQuery(pick(query, params)),
     connection: {
       remoteAddress: req.connection.remoteAddress,
       remotePort: req.connection.remotePort,
     },
   };
 
-  // Copy headers, removing cookies from the noise
-  request.headers = Object.assign({}, req.headers);
-  delete request.headers.cookie;
+  // Copy only headers we wish to log
+  request.headers = pick(Object.assign({}, req.headers), headersToLog);
 
   return request;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,9 +56,12 @@ module.exports.pick = pick;
 
 
 const headersToLog = [
-  'user-agent',
-  'referer',
   'cache-control',
+  'host',
+  'referer',
+  'user-agent',
+  'x-real-ip',
+  'x-forwarded-for',
 ];
 /**
  * getRequestDataToLog

--- a/middleware.js
+++ b/middleware.js
@@ -14,11 +14,12 @@ module.exports = function middleware(options) {
   const {
     getMetadata,
     getStats,
+    params,
   } = options;
 
   return function logRequest(req, res, next) {
     const startTime = new Date();
-    const request = getRequestDataToLog(req);
+    const request = getRequestDataToLog(req, params);
 
     onFinished(res, () => {
       const finishTime = new Date();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/logger",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Logging for Buffer.com's node applications",
   "main": "logger.js",
   "scripts": {

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -77,17 +77,23 @@ describe('utils', () => {
           remotePort: 40234,
         },
         headers: {
+          host: 'buffer.com',
           'user-agent': 'Mozilla/5.0',
           referer: 'https://twitter.com',
           'cache-control': 'no-cache',
+          'x-real-ip': '172.18.0.1',
+          'x-forwarded-for': '172.18.0.1',
           'x-something-bogus': false,
-        }
+        },
       };
       const data = getRequestDataToLog(req);
       assert.deepEqual(data.headers, {
+        host: 'buffer.com',
         'user-agent': 'Mozilla/5.0',
         referer: 'https://twitter.com',
         'cache-control': 'no-cache',
+        'x-real-ip': '172.18.0.1',
+        'x-forwarded-for': '172.18.0.1',
       });
     });
 


### PR DESCRIPTION
### Purpose
To remove non specified fields to reduce noise. We were getting too many random or obscure headers and unexpected params which was causing our elasticsearch indexes to run out of fields.