### PR TITLE
Use BuffLog for logging middleware requests

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,4 +1,5 @@
 const createLogger = require('./logger');
+const BuffLog = require('bufflog');
 const onFinished = require('on-finished');
 const { getRequestDataToLog } = require('./lib/utils');
 
@@ -10,7 +11,6 @@ const { getRequestDataToLog } = require('./lib/utils');
  * @return {Function}
  */
 module.exports = function middleware(options) {
-  const logger = createLogger(options);
   const {
     getMetadata,
     getStats,
@@ -47,7 +47,12 @@ module.exports = function middleware(options) {
         stats,
       };
 
-      logger.info(info, msg);
+      if (response.error) {
+        BuffLog.error(msg, info);
+      } else {
+        BuffLog.info(msg, info);
+      }
+
     });
 
     next();

--- a/middleware.js
+++ b/middleware.js
@@ -1,4 +1,3 @@
-const createLogger = require('./logger');
 const BuffLog = require('bufflog');
 const onFinished = require('on-finished');
 const { getRequestDataToLog } = require('./lib/utils');
@@ -52,7 +51,6 @@ module.exports = function middleware(options) {
       } else {
         BuffLog.info(msg, info);
       }
-
     });
 
     next();

--- a/middleware.js
+++ b/middleware.js
@@ -1,4 +1,4 @@
-const BuffLog = require('@bufferapp/bufflog');
+const bufflog = require('@bufferapp/bufflog');
 const onFinished = require('on-finished');
 const { getRequestDataToLog } = require('./lib/utils');
 
@@ -47,9 +47,9 @@ module.exports = function middleware(options) {
       };
 
       if (response.error) {
-        BuffLog.error(msg, info);
+        bufflog.error(msg, info);
       } else {
-        BuffLog.info(msg, info);
+        bufflog.info(msg, info);
       }
     });
 

--- a/middleware.js
+++ b/middleware.js
@@ -1,4 +1,4 @@
-const BuffLog = require('bufflog');
+const BuffLog = require('@bufferapp/bufflog');
 const onFinished = require('on-finished');
 const { getRequestDataToLog } = require('./lib/utils');
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@bufferapp/bufflog": "0.0.3",
-    "bunyan": "1.8.1",
+    "bunyan": "^1.8.12",
     "fluent-logger": "2.2.0",
     "on-finished": "2.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/logger",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Logging for Buffer.com's node applications",
   "main": "logger.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@bufferapp/bufflog": "0.0.3",
     "bunyan": "1.8.1",
-    "on-finished": "2.3.0",
-    "fluent-logger": "2.2.0"
+    "fluent-logger": "2.2.0",
+    "on-finished": "2.3.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/logger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Logging for Buffer.com's node applications",
   "main": "logger.js",
   "scripts": {
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@bufferapp/bufflog": "0.0.3",
+    "@bufferapp/bufflog": "0.0.4",
     "bunyan": "^1.8.12",
     "fluent-logger": "2.2.0",
     "on-finished": "2.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/logger",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "Logging for Buffer.com's node applications",
   "main": "logger.js",
   "scripts": {
@@ -34,7 +34,7 @@
     "eslint-plugin-jsx-a11y": "^1.2.3",
     "eslint-plugin-react": "^5.1.1",
     "istanbul": "^0.4.3",
-    "mocha": "^2.5.3",
+    "mocha": "^7.1.0",
     "msgpack-lite": "^0.1.26"
   }
 }


### PR DESCRIPTION
Use [`BuffLog`](https://www.npmjs.com/package/@bufferapp/bufflog) for logging middleware requests. 

Also bumped the major version to avoid any unwanted upgrade. 

@djfarrelly up for a quick review? 