### PR TITLE
Better error message for middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -47,7 +47,7 @@ module.exports = function middleware(options) {
       };
 
       if (response.error) {
-        bufflog.error(msg, info);
+        bufflog.error(response.error, info);
       } else {
         bufflog.info(msg, info);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bufferapp/logger",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Logging for Buffer.com's node applications",
   "main": "logger.js",
   "scripts": {


### PR DESCRIPTION
Instead of having the link as the error message, make it more useful so we can group it in Datadog